### PR TITLE
Add interactive business plan generator webpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,533 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Startup Idea to Business Plan Assistant</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #0d1b2a;
+      --panel: rgba(255, 255, 255, 0.08);
+      --accent: #1abc9c;
+      --accent-dark: #138a72;
+      --text: #e9f1f7;
+      --muted: #94a3b8;
+      font-size: 16px;
+      font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+    }
+
+    body {
+      margin: 0;
+      background: linear-gradient(135deg, rgba(13, 27, 42, 0.95), rgba(15, 76, 117, 0.8));
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      padding: 2.5rem 5vw 1.5rem;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: clamp(2rem, 5vw, 3rem);
+      letter-spacing: 0.04em;
+    }
+
+    header p {
+      color: var(--muted);
+      max-width: 60ch;
+    }
+
+    main {
+      flex: 1;
+      display: grid;
+      grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+      gap: 2rem;
+      padding: 0 5vw 3rem;
+    }
+
+    section, aside {
+      background: var(--panel);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 1.5rem;
+      padding: 1.8rem;
+      backdrop-filter: blur(14px);
+      box-shadow: 0 25px 55px rgba(0, 0, 0, 0.25);
+      display: flex;
+      flex-direction: column;
+      gap: 1.2rem;
+    }
+
+    .question-counter {
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .question {
+      font-size: 1.3rem;
+      margin: 0;
+      line-height: 1.4;
+    }
+
+    textarea, input[type="text"] {
+      width: 100%;
+      border-radius: 0.9rem;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      background: rgba(15, 76, 117, 0.25);
+      color: inherit;
+      padding: 1rem 1.1rem;
+      min-height: 150px;
+      font-size: 1rem;
+      line-height: 1.5;
+      resize: vertical;
+      transition: border 160ms ease, background 160ms ease;
+    }
+
+    input[type="text"] {
+      min-height: auto;
+    }
+
+    textarea:focus, input[type="text"]:focus {
+      outline: none;
+      border-color: var(--accent);
+      background: rgba(26, 188, 156, 0.08);
+    }
+
+    .controls {
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    button {
+      border: none;
+      border-radius: 999px;
+      padding: 0.85rem 1.6rem;
+      font-size: 0.95rem;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+      cursor: pointer;
+      transition: transform 160ms ease, background 160ms ease, box-shadow 160ms ease;
+    }
+
+    button.primary {
+      background: var(--accent);
+      color: #0b1620;
+      box-shadow: 0 15px 35px rgba(26, 188, 156, 0.4);
+    }
+
+    button.primary:hover {
+      background: var(--accent-dark);
+      transform: translateY(-1px);
+    }
+
+    button.secondary {
+      background: transparent;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      color: inherit;
+    }
+
+    button.secondary:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    .plan-preview {
+      background: rgba(8, 18, 28, 0.55);
+      border-radius: 1.2rem;
+      padding: 1.5rem;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      font-size: 0.98rem;
+      line-height: 1.6;
+      max-height: 55vh;
+      overflow-y: auto;
+      white-space: pre-line;
+    }
+
+    .placeholder {
+      color: var(--muted);
+      text-align: center;
+      padding: 4rem 1rem;
+    }
+
+    .progress {
+      height: 8px;
+      background: rgba(255, 255, 255, 0.1);
+      border-radius: 999px;
+      overflow: hidden;
+    }
+
+    .progress span {
+      display: block;
+      height: 100%;
+      background: var(--accent);
+      width: 0;
+      transition: width 200ms ease;
+    }
+
+    .saved-list {
+      display: flex;
+      flex-direction: column;
+      gap: 0.9rem;
+      overflow-y: auto;
+      max-height: 65vh;
+      padding-right: 0.3rem;
+    }
+
+    .saved-item {
+      background: rgba(255, 255, 255, 0.05);
+      border-radius: 1rem;
+      padding: 1rem 1.2rem;
+      border: 1px solid transparent;
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+      transition: border 160ms ease, transform 160ms ease;
+      cursor: pointer;
+    }
+
+    .saved-item:hover {
+      border-color: rgba(26, 188, 156, 0.4);
+      transform: translateY(-2px);
+    }
+
+    .saved-item.active {
+      border-color: var(--accent);
+      background: rgba(26, 188, 156, 0.1);
+    }
+
+    .saved-item h4 {
+      margin: 0;
+      font-size: 1.05rem;
+    }
+
+    .saved-item span {
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+
+    @media (max-width: 1100px) {
+      main {
+        grid-template-columns: 1fr;
+      }
+
+      aside {
+        order: -1;
+      }
+    }
+
+    @media (max-width: 600px) {
+      header, main {
+        padding-left: 1.2rem;
+        padding-right: 1.2rem;
+      }
+
+      section, aside {
+        padding: 1.2rem;
+        border-radius: 1.1rem;
+      }
+
+      button {
+        width: 100%;
+      }
+
+      .controls {
+        flex-direction: column;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Idea Architect</h1>
+    <p>
+      A guided workspace that interviews you about your startup idea and instantly shapes your answers into
+      a polished business plan. Save each concept and revisit them as your thinking evolves.
+    </p>
+  </header>
+  <main>
+    <section aria-labelledby="question-heading">
+      <div class="progress" aria-hidden="true">
+        <span id="progress-bar"></span>
+      </div>
+      <div class="question-counter" id="question-counter">Question 1 of 9</div>
+      <h2 id="question-heading" class="question">Tell me about your startup idea.</h2>
+      <textarea id="response" placeholder="Describe your idea in a few sentences..."></textarea>
+      <div class="controls">
+        <button type="button" class="secondary" id="prev-btn" disabled>Previous</button>
+        <div style="display:flex; gap:0.75rem; flex-wrap: wrap;">
+          <button type="button" class="secondary" id="clear-btn">Reset</button>
+          <button type="button" class="primary" id="next-btn">Next</button>
+        </div>
+      </div>
+    </section>
+    <aside>
+      <div>
+        <h3 style="margin:0;">Saved Business Plans</h3>
+        <p style="margin:0; color:var(--muted);">Click an idea to read its generated plan.</p>
+      </div>
+      <div class="saved-list" id="saved-list">
+        <p class="placeholder" id="placeholder">No ideas saved yet. Craft your first plan to see it here.</p>
+      </div>
+      <button type="button" class="primary" id="save-btn" disabled>Save this Plan</button>
+    </aside>
+    <section aria-labelledby="plan-heading">
+      <h2 id="plan-heading" style="margin:0;">Business Plan Preview</h2>
+      <p style="margin:0; color:var(--muted);">Your plan updates as you answer questions. Finish all steps to unlock saving.</p>
+      <article class="plan-preview" id="plan-preview">
+        <p class="placeholder">Answer the questions to generate a strategic summary.</p>
+      </article>
+    </section>
+  </main>
+
+  <template id="saved-item-template">
+    <div class="saved-item" role="button" tabindex="0">
+      <h4></h4>
+      <span></span>
+    </div>
+  </template>
+
+  <script>
+    const steps = [
+      {
+        key: 'vision',
+        question: 'Pitch your idea in one bold sentence. What problem are you solving?',
+        placeholder: 'We help busy professionals eat healthy meals without cooking by...'
+      },
+      {
+        key: 'audience',
+        question: 'Who desperately needs this solution? Describe your primary customers.',
+        placeholder: 'Our target audience is...'
+      },
+      {
+        key: 'value',
+        question: 'What makes your approach stand out from alternatives?',
+        placeholder: 'Unlike competitors, we...'
+      },
+      {
+        key: 'solution',
+        question: 'How does your product or service actually work? Walk through the experience.',
+        placeholder: 'Users discover us via..., sign up by..., and then...'
+      },
+      {
+        key: 'revenue',
+        question: 'How will you make money? Detail your revenue model or pricing strategy.',
+        placeholder: 'We generate revenue through...'
+      },
+      {
+        key: 'marketing',
+        question: 'What is your go-to-market plan? Outline acquisition and retention tactics.',
+        placeholder: 'To attract customers we will...'
+      },
+      {
+        key: 'operations',
+        question: 'What does it take to deliver this reliably? Consider team, tech, and partners.',
+        placeholder: 'Key partners and resources include...'
+      },
+      {
+        key: 'finances',
+        question: 'What funding or resources do you need to launch and scale?',
+        placeholder: 'We require... to reach...'
+      },
+      {
+        key: 'milestones',
+        question: 'What major milestones will prove traction over the next 12-18 months?',
+        placeholder: 'Quarter 1: ..., Quarter 2: ...'
+      }
+    ];
+
+    const state = steps.reduce((acc, step) => ({ ...acc, [step.key]: '' }), {});
+    let currentStep = 0;
+    let savedPlans = [];
+
+    const responseField = document.getElementById('response');
+    const questionHeading = document.getElementById('question-heading');
+    const questionCounter = document.getElementById('question-counter');
+    const progressBar = document.getElementById('progress-bar');
+    const nextBtn = document.getElementById('next-btn');
+    const prevBtn = document.getElementById('prev-btn');
+    const clearBtn = document.getElementById('clear-btn');
+    const saveBtn = document.getElementById('save-btn');
+    const planPreview = document.getElementById('plan-preview');
+    const savedList = document.getElementById('saved-list');
+    const placeholder = document.getElementById('placeholder');
+    const savedItemTemplate = document.getElementById('saved-item-template');
+
+    function updateStep() {
+      const step = steps[currentStep];
+      questionHeading.textContent = step.question;
+      questionCounter.textContent = `Question ${currentStep + 1} of ${steps.length}`;
+      responseField.placeholder = step.placeholder;
+      responseField.value = state[step.key];
+      prevBtn.disabled = currentStep === 0;
+      nextBtn.textContent = currentStep === steps.length - 1 ? 'Generate Plan' : 'Next';
+      const progress = (currentStep / (steps.length - 1)) * 100;
+      progressBar.style.width = `${progress}%`;
+      renderPlan();
+    }
+
+    function renderPlan(planState = state) {
+      const allAnswered = steps.every((step) => planState[step.key].trim());
+      const ideaTitle = planState.vision.split('.')[0] || 'Untitled Idea';
+      const sections = [
+        { title: 'Executive Summary', content: `${planState.vision}\n\nWe serve: ${planState.audience}.` },
+        { title: 'Unique Value Proposition', content: planState.value },
+        { title: 'Product & Experience', content: planState.solution },
+        { title: 'Revenue Model', content: planState.revenue },
+        { title: 'Go-To-Market Strategy', content: planState.marketing },
+        { title: 'Operations Plan', content: planState.operations },
+        { title: 'Financial Needs', content: planState.finances },
+        { title: 'Roadmap & Milestones', content: planState.milestones }
+      ];
+
+      if (!Object.values(planState).some((value) => value.trim())) {
+        planPreview.innerHTML = '<p class="placeholder">Answer the questions to generate a strategic summary.</p>';
+        saveBtn.disabled = true;
+        return;
+      }
+
+      const planText = sections
+        .map((section) => `# ${section.title}\n${section.content.trim() || 'Add more detail here.'}`)
+        .join('\n\n');
+
+      planPreview.textContent = `${ideaTitle}\n\n${planText}`;
+      saveBtn.disabled = !allAnswered;
+    }
+
+    function persistPlans() {
+      localStorage.setItem('businessPlans', JSON.stringify(savedPlans));
+    }
+
+    function formatDate(ts) {
+      return new Intl.DateTimeFormat('en', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(ts));
+    }
+
+    function renderSavedList() {
+      savedList.innerHTML = '';
+      if (!savedPlans.length) {
+        savedList.appendChild(placeholder);
+        placeholder.style.display = 'block';
+        return;
+      }
+
+      placeholder.style.display = 'none';
+        savedPlans
+          .slice()
+          .sort((a, b) => b.savedAt - a.savedAt)
+          .forEach((plan) => {
+            const node = savedItemTemplate.content.firstElementChild.cloneNode(true);
+            node.dataset.id = plan.id;
+            node.querySelector('h4').textContent = plan.title;
+            node.querySelector('span').textContent = formatDate(plan.savedAt);
+            node.addEventListener('click', () => openSavedPlan(plan.id));
+            node.addEventListener('keypress', (event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                openSavedPlan(plan.id);
+              }
+            });
+            if (plan.id === activePlanId) {
+              node.classList.add('active');
+            }
+            savedList.appendChild(node);
+          });
+    }
+
+    let activePlanId = null;
+
+    function openSavedPlan(id) {
+      const plan = savedPlans.find((item) => item.id === id);
+      if (!plan) return;
+      activePlanId = id;
+      renderPlan(plan.answers);
+      document.querySelectorAll('.saved-item').forEach((item) => item.classList.remove('active'));
+      const match = Array.from(savedList.children).find((node) => node.dataset.id === id);
+      if (match) {
+        match.classList.add('active');
+      }
+    }
+
+    nextBtn.addEventListener('click', () => {
+      state[steps[currentStep].key] = responseField.value.trim();
+      if (!state[steps[currentStep].key]) {
+        responseField.focus();
+        return;
+      }
+
+      if (currentStep === steps.length - 1) {
+        renderPlan();
+        responseField.blur();
+        return;
+      }
+
+      currentStep += 1;
+      updateStep();
+      responseField.focus();
+    });
+
+    prevBtn.addEventListener('click', () => {
+      state[steps[currentStep].key] = responseField.value.trim();
+      if (currentStep === 0) return;
+      currentStep -= 1;
+      updateStep();
+      responseField.focus();
+    });
+
+    clearBtn.addEventListener('click', () => {
+      if (!confirm('Clear all answers and start fresh?')) return;
+      Object.keys(state).forEach((key) => (state[key] = ''));
+      currentStep = 0;
+      activePlanId = null;
+      updateStep();
+    });
+
+    responseField.addEventListener('input', () => {
+      state[steps[currentStep].key] = responseField.value;
+      renderPlan();
+    });
+
+    saveBtn.addEventListener('click', () => {
+      const answers = steps.reduce((acc, step) => ({ ...acc, [step.key]: state[step.key].trim() }), {});
+      const title = answers.vision.split('.')[0] || 'Untitled Idea';
+      const payload = {
+        id: crypto.randomUUID(),
+        title,
+        answers,
+        plan: planPreview.textContent,
+        savedAt: Date.now()
+      };
+      savedPlans.push(payload);
+      persistPlans();
+      renderSavedList();
+      activePlanId = payload.id;
+      renderPlan();
+      alert('Plan saved! Find it in the list on the right.');
+    });
+
+    function loadPlans() {
+      try {
+        const stored = JSON.parse(localStorage.getItem('businessPlans') || '[]');
+        if (Array.isArray(stored)) {
+          savedPlans = stored;
+        }
+      } catch (error) {
+        console.error('Failed to parse saved plans', error);
+      }
+      renderSavedList();
+    }
+
+    document.addEventListener('keydown', (event) => {
+      if (event.ctrlKey && event.key === 'Enter') {
+        nextBtn.click();
+      }
+    });
+
+    loadPlans();
+    updateStep();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a glassmorphism-inspired single page that guides users through nine startup discovery questions
- auto-generate a structured business plan preview that updates with every answer and gates saving until all prompts are filled
- persist generated plans to localStorage with a browsable history panel for quick review

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d049327b9483209f864b7010dfbb86